### PR TITLE
Typo fix: change re-declaration of self.Vd to self.Ud

### DIFF
--- a/coastalimagelib/corefunctions.py
+++ b/coastalimagelib/corefunctions.py
@@ -732,7 +732,7 @@ class CameraData(object):
         self.coords = coords
         self.mType = mType
         self.nc = nc
-        self.Vd = "None"
+        self.Ud = "None"
         self.Vd = "None"
 
         # If in geo coordinates, convert to local


### PR DESCRIPTION
Without this change, a user trying to run the example notebook will encounter an error in `cf.mergeRectify()` which checks for the (non-existent) `calib.Ud`: 

https://github.com/mailemccann/coastalimagelib/blob/c25caaf2ea7cadff2a9ccb3fd2db4f3ef2d98a5a/coastalimagelib/corefunctions.py#L512